### PR TITLE
chore:[CO-360] AlwaysOnCluster cleanup 

### DIFF
--- a/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
+++ b/src/java/com/zimbra/cs/nginx/NginxLookupExtension.java
@@ -1257,28 +1257,6 @@ public class NginxLookupExtension implements ZimbraExtension {
                         return;
                     }
                 }
-                Server accountHostingServer = prov.getServerByServiceHostname(conn.host);
-                if (accountHostingServer != null) {
-                    String clusterId = accountHostingServer.getAlwaysOnClusterId();
-                    if (clusterId != null) {
-                        List<Server> servers = prov.getAllServers(Provisioning.SERVICE_MAILBOX, clusterId);
-                        Iterator<Server> iter = servers.iterator();
-                        while (iter.hasNext()) {
-                            Server s = iter.next();
-                            if (!activeServers.contains(s.getId())) {
-                                iter.remove();
-                            }
-                        }
-                        if (!servers.isEmpty()) {
-                            // choose the server randomly from the servers list.
-                            Server selectedServer = servers.get(random.nextInt(servers.size()));
-                            conn.host = selectedServer.getServiceHostname();
-                            // store this server info in zookeeper
-                            curatorManager.setData(authUserWithRealDomainName,
-                                    selectedServer.getId() + ":" + conn.host);
-                        }
-                    }
-                }
             } catch (Exception e) {
                 throw new NginxLookupException(e);
             }


### PR DESCRIPTION
**Key Changes:**
- remove the call to the removed server.getAlwaysOnClusterId method

Parent PR: https://github.com/Zextras/carbonio-mailbox/pull/80
